### PR TITLE
A few small accessibility improvements

### DIFF
--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -80,23 +80,23 @@ nav {
   li {
     display: inline-block;
   }
-}
 
-nav#user-nav {
-	padding: 1em 0 0 0;
-	text-align: right;
+  &#user-nav {
+    padding: 1em 0 0 0;
+    text-align: right;
 
-  li {
-    margin-left: .25em;
+    li {
+      margin-left: .25em;
+    }
   }
-}
 
-nav#main-nav {
-	font-size: 1.5em;
-	font-weight: bold;
-	span {
-		margin: 0 1em;
-	}
+  &#main-nav {
+    font-size: 1.5em;
+    font-weight: bold;
+    span {
+      margin: 0 1em;
+    }
+  }
 }
 
 header {

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -94,7 +94,7 @@ nav {
     font-size: 1.5em;
     font-weight: bold;
 
-    span {
+    li {
       margin: 0 1em;
     }
   }

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -93,6 +93,7 @@ nav {
   &#main-nav {
     font-size: 1.5em;
     font-weight: bold;
+
     span {
       margin: 0 1em;
     }

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -71,6 +71,17 @@ li.hidden {
 	opacity: 0.5;
 }
 
+nav {
+  ul {
+    padding: 0;
+    margin: 0;
+  }
+
+  li {
+    display: inline-block;
+  }
+}
+
 nav#user-nav {
 	padding: 1em 0 0 0;
 	text-align: right;

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -85,6 +85,10 @@ nav {
 nav#user-nav {
 	padding: 1em 0 0 0;
 	text-align: right;
+
+  li {
+    margin-left: .25em;
+  }
 }
 
 nav#main-nav {

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -76,24 +76,19 @@ nav {
     padding: 0;
     margin: 0;
   }
-
   li {
     display: inline-block;
   }
-
   &#user-nav {
     padding: 1em 0 0 0;
     text-align: right;
-
     li {
       margin-left: .25em;
     }
   }
-
   &#main-nav {
     font-size: 1.5em;
     font-weight: bold;
-
     li {
       margin: 0 1em;
     }

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -72,27 +72,27 @@ li.hidden {
 }
 
 nav {
-  ul {
-    padding: 0;
-    margin: 0;
-  }
-  li {
-    display: inline-block;
-  }
-  &#user-nav {
-    padding: 1em 0 0 0;
-    text-align: right;
-    li {
-      margin-left: .25em;
-    }
-  }
-  &#main-nav {
-    font-size: 1.5em;
-    font-weight: bold;
-    li {
-      margin: 0 1em;
-    }
-  }
+	ul {
+		padding: 0;
+		margin: 0;
+	}
+	li {
+		display: inline-block;
+	}
+	&#user-nav {
+		padding: 1em 0 0 0;
+		text-align: right;
+		li {
+			margin-left: .25em;
+		}
+	}
+	&#main-nav {
+		font-size: 1.5em;
+		font-weight: bold;
+		li {
+			margin: 0 1em;
+		}
+	}
 }
 
 header {

--- a/routes/main.js
+++ b/routes/main.js
@@ -29,7 +29,7 @@ function configure_router (passport) {
 			},{
 				name: 'Listings',
 				link:'/',
-				title: 'Find and share the things you need to make the art.'
+				title: 'Find and share the things you need to make art.'
 				}],
 			user: req.user,
 			message: req.flash('message'),

--- a/routes/main.js
+++ b/routes/main.js
@@ -29,7 +29,7 @@ function configure_router (passport) {
 			},{
 				name: 'Listings',
 				link:'/',
-				title: 'Find and share the things you need to make art.'
+				title: 'Find the things you need to make art and share the things you have for others.'
 				}],
 			user: req.user,
 			message: req.flash('message'),

--- a/routes/main.js
+++ b/routes/main.js
@@ -24,10 +24,12 @@ function configure_router (passport) {
 			path: req.path,
 			menu: [{ 
 				name: 'About',
-				link:'/about' 
+				link:'/about',
+ 				title: 'Learn about about this project.'
 			},{ 
 				name: 'Listings',
 				link:'/',
+				title: 'Find and share the things you need to make the art.'
 				}],
 			user: req.user,
 			message: req.flash('message'),

--- a/routes/main.js
+++ b/routes/main.js
@@ -22,11 +22,11 @@ function configure_router (passport) {
 		req.data = {
 			title: 'Arts Assets Prototype',
 			path: req.path,
-			menu: [{ 
+			menu: [{
 				name: 'About',
 				link:'/about',
  				title: 'Learn about about this project.'
-			},{ 
+			},{
 				name: 'Listings',
 				link:'/',
 				title: 'Find and share the things you need to make the art.'

--- a/views/base.dust
+++ b/views/base.dust
@@ -19,7 +19,7 @@
 			<h1>{title}</h1>
 			<nav id="main-nav">
 				{#menu}
-					<span>{@ne key=link value=path}<a href="{link}">{name}</a>{:else}{name}{/ne}</span>
+					<span>{@ne key=link value=path}<a href="{link}" title="{title}">{name}</a>{:else}{name}{/ne}</span>
 				{/menu}
 				{?user}
 					<span>{@ne key=path value="/profile"}<a href="/profile">Profile</a>{:else}Profile{/ne}</span>

--- a/views/base.dust
+++ b/views/base.dust
@@ -9,12 +9,23 @@
 	<div class="wrapper">
 		<header class="row">
 			<nav id="user-nav">
-				{?user}
-					(Logged in as <a href="/profile">{user.name}</a>) <a href="/logout">logout</a>
-				{:else}
-					<a href="/login">login</a> or 
-					<a href="/signup">sign up</a>
-				{/user}
+				<ul>
+					{?user}
+						<li>
+							(Logged in as <a href="/profile">{user.name}</a>)
+						</li>
+						<li>
+							<a href="/logout">logout</a>
+						</li>
+					{:else}
+						<li>
+							<a href="/login">login</a> or
+						</li>
+						<li>
+							<a href="/signup">sign up</a>
+						</li>
+					{/user}
+				</ul>
 			</nav>
 			<h1>{title}</h1>
 			<nav id="main-nav">

--- a/views/base.dust
+++ b/views/base.dust
@@ -32,12 +32,12 @@
 				<ul>
 					{#menu}
 						<li>
-							<span>{@ne key=link value=path}<a href="{link}" title="{title}">{name}</a>{:else}{name}{/ne}</span>
+							{@ne key=link value=path}<a href="{link}" title="{title}">{name}</a>{:else}{name}{/ne}
 						</li>
 					{/menu}
 					{?user}
 						<li>
-							<span>{@ne key=path value="/profile"}<a href="/profile">Profile</a>{:else}Profile{/ne}</span>
+							{@ne key=path value="/profile"}<a href="/profile">Profile</a>{:else}Profile{/ne}
 						</li>
 					{/user}
 				</ul>

--- a/views/base.dust
+++ b/views/base.dust
@@ -18,12 +18,18 @@
 			</nav>
 			<h1>{title}</h1>
 			<nav id="main-nav">
-				{#menu}
-					<span>{@ne key=link value=path}<a href="{link}" title="{title}">{name}</a>{:else}{name}{/ne}</span>
-				{/menu}
-				{?user}
-					<span>{@ne key=path value="/profile"}<a href="/profile">Profile</a>{:else}Profile{/ne}</span>
-				{/user}
+				<ul>
+					{#menu}
+						<li>
+							<span>{@ne key=link value=path}<a href="{link}" title="{title}">{name}</a>{:else}{name}{/ne}</span>
+						</li>
+					{/menu}
+					{?user}
+						<li>
+							<span>{@ne key=path value="/profile"}<a href="/profile">Profile</a>{:else}Profile{/ne}</span>
+						</li>
+					{/user}
+				</ul>
 			</nav>
 		</header>
 		<hr>


### PR DESCRIPTION
This makes a couple of small improvements to the overall accessibility:
- adds title text to main-nav links
- makes the navigation menus semantic <ul>s instead of being inline spans. This means they get read out as distinct elements, rather than a single sentence.

It impact the visual appearance of the elements at all.

I couldn't test this while logged in because I don't have that configured in dev (see https://trello.com/c/OrEAjydq/121-add-documentation-on-how-to-setup-users-and-run-email-without-mailgun-in-development). If you could test this out and post a screen shot of any issues that would be great @e-e-e .
