### PR TITLE
Adjust navigation and match design

### DIFF
--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -95,17 +95,12 @@ nav {
 }
 }
 
-header {
-	height: 1px;
-}
-
 main {
 	width: 100%;
 	height: 100%;
 }
 
 footer {
-	height: 1px;
 	text-align: center;
 }
 
@@ -137,18 +132,7 @@ label div.thing {
 	display: table;
 }
 
-.table {
-	display: table;
-	// height: 100%;
-	width: 100%;
-}
-
-.row {
-	display: table-row;
-}
-
 .cell {
-	display: table-cell;
 	width: 50%;
 }
 

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -209,6 +209,20 @@ textarea {
 	}
 }
 
+.match-things {
+	@media only screen and (min-width: 30em) {
+		display: flex;
+	}
+
+	.thing {
+		flex: .5;
+
+		&:first-child {
+			border-right: 1px #aaa solid;
+		}
+	}
+}
+
 .match-actions {
 	ul {
 		margin: 0;

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -3,6 +3,7 @@
 @link-color: #F00;
 @error-color: #F00;
 @message-color: green;
+@small-screen-breakpoint: 35em;
 
 // * { margin:0; padding:0;}
 html, body { 
@@ -74,22 +75,59 @@ div.hidden {
 	opacity: 0.5;
 }
 
+.site-header {
+	padding: 1em;
+	text-align: center;
+
+	@media only screen and (min-width: @small-screen-breakpoint) {
+		display: flex;
+		justify-content: space-between;
+	}
+}
+
 nav {
+	ul {
+		margin: 0;
+		padding: 0;
+	}
 	li {
 		display: inline-block;
 	}
 	&#user-nav {
 		padding: 1em 0 0 0;
 		text-align: right;
+		@media only screen and (min-width: @small-screen-breakpoint) {
+			padding: 0;
+			display: flex;
+			align-items: center;
+		}
 		li {
 			margin-left: .25em;
 		}
 	}
 	&#main-nav {
-	font-size: 1.5em;
 	font-weight: bold;
+	@media only screen and (min-width: @small-screen-breakpoint) {
+		text-align: left;
+	}
+
+	.site-title {
+		margin: 0;
+		display: inline-block;
+		font-size: 1.5em;
+	}
+
+	ul {
+		padding: 0;
+		@media only screen and (min-width: @small-screen-breakpoint) {
+			margin: 0;
+			display: inline-block;
+		}
+	}
+
 	li {
 		margin: 0 1em;
+		font-size: 1.25em;
 	}
 }
 }

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -17,7 +17,8 @@ body, html {
 	margin: 0 auto;
 	padding: 0;
 	font-family: helvetica, sans-serif;
-	font-size: 13px;
+	font-size: 17px;
+	line-height: 1.6;
 }
 
 hr {
@@ -29,10 +30,6 @@ hr {
 
 h1 {
 	text-align: center;
-}
-
-main p {
-	line-height: 1.75em;
 }
 
 *::selection {

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -46,6 +46,35 @@ a {
 	}
 }
 
+a.button,
+.button,
+button {
+	margin: 0 0 1em;
+	font-size: 1em;
+	padding: .5em 1em;
+	border: 0;
+	border-radius: .5em;
+	background-color: #eee;
+	appearance: none;
+	color: @body-color;
+	text-decoration: none;
+	cursor: pointer;
+
+	&:hover,
+	&:focus {
+		background-color: #bbb;
+	}
+}
+
+.primary-button {
+	background-color: tint(@message-color,90%);
+
+	&:hover,
+	&:focus {
+		background-color: tint(@message-color,80%);
+	}
+}
+
 div.error {
 	background-color: tint(@error-color,90%);
 	color: @error-color;
@@ -229,14 +258,8 @@ textarea {
 		padding: 0;
 	}
 
-	a,
-	button{
+	.button {
 		margin: 0 0 1em;
-		font-size: 1em;
-		padding: .5em 1em;
-		border: 0;
-		border-radius: .5em;
-		background: #eee;
-		appearance: none;
+		text-align: left;
 	}
 }

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -168,6 +168,7 @@ label div.thing {
 	width: 100%;
 	max-width: @maxwidth;
 	margin: 0 auto;
+	padding: 0 1em;
 }
 
 .things-list {

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -196,7 +196,6 @@ label div.thing {
 }
 
 .wrapper {
-	width: 100%;
 	max-width: @maxwidth;
 	margin: 0 auto;
 	padding: 0 1em;

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -258,6 +258,11 @@ textarea {
 		padding: 0;
 	}
 
+	li {
+		margin-right: 1em;
+		display: inline-block;
+	}
+
 	.button {
 		margin: 0 0 1em;
 		text-align: left;

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -66,12 +66,13 @@ button {
 	}
 }
 
+a.primary-button,
 .primary-button {
-	background-color: tint(@message-color,90%);
+	background-color: tint(@message-color,80%);
 
 	&:hover,
 	&:focus {
-		background-color: tint(@message-color,80%);
+		background-color: tint(@message-color,70%);
 	}
 }
 

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -267,5 +267,9 @@ textarea {
 	.button {
 		margin: 0 0 1em;
 		text-align: left;
+
+		@media only screen and (min-width: 30em) {
+			margin: 0;
+		}
 	}
 }

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -13,7 +13,6 @@ html, body {
 
 body, html {
 	color: @body-color;
-	max-width: @maxwidth;
 	margin: 0 auto;
 	padding: 0;
 	font-family: helvetica, sans-serif;
@@ -129,7 +128,8 @@ label div.thing {
 .wrapper {
 	height: 100%;
 	width: 100%;
-	display: table;
+	max-width: @maxwidth;
+	margin: 0 auto;
 }
 
 .things-list {

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -132,8 +132,13 @@ label div.thing {
 	display: table;
 }
 
+.things-list {
+	display: flex;
+}
+
 .cell {
 	width: 50%;
+	flex: 1;
 }
 
 section#haves, section#needs {

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -193,3 +193,36 @@ textarea {
 	width: 100%;
 	resize: vertical;
 }
+
+.match-pair {
+	margin: 0 0 2em;
+	border: 1px #aaa solid;
+	border-radius: .5em;
+
+	.thing,
+	.match-actions {
+		padding: 1em;
+	}
+
+	.thing {
+		border-bottom: 1px #aaa solid;
+	}
+}
+
+.match-actions {
+	ul {
+		margin: 0;
+		padding: 0;
+	}
+
+	a,
+	button{
+		margin: 0 0 1em;
+		font-size: 1em;
+		padding: .5em 1em;
+		border: 0;
+		border-radius: .5em;
+		background: #eee;
+		appearance: none;
+	}
+}

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -253,6 +253,7 @@ textarea {
 }
 
 .match-actions {
+	p,
 	ul {
 		margin: 0;
 		padding: 0;

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -132,11 +132,6 @@ nav {
 }
 }
 
-main {
-	width: 100%;
-	height: 100%;
-}
-
 footer {
 	text-align: center;
 }
@@ -164,7 +159,6 @@ label div.thing {
 }
 
 .wrapper {
-	height: 100%;
 	width: 100%;
 	max-width: @maxwidth;
 	margin: 0 auto;

--- a/public/src/less/style.less
+++ b/public/src/less/style.less
@@ -132,8 +132,15 @@ nav {
 }
 }
 
-footer {
+.site-footer {
+	margin: 3em 0 0;
+	border-top: 1px solid #000;
+	padding: 1em 0;
 	text-align: center;
+
+	p {
+		margin: 0;
+	}
 }
 
 ul {

--- a/views/base.dust
+++ b/views/base.dust
@@ -48,8 +48,7 @@
 		<main>
 			{+content/}
 		</main>
-		<hr>
-		<footer>
+		<footer class="site-footer">
 			<p>This project is proudly opensource. Contibute or check out the code at <a href="https://github.com/frontyardprojects/a-non-cash-assets-library" target="__blank">github</a>.</p>
 		</footer>
 	</div>

--- a/views/base.dust
+++ b/views/base.dust
@@ -7,7 +7,7 @@
 </head>
 <body>
 	<div class="wrapper">
-		<header class="row">
+		<header>
 			<nav id="user-nav">
 				<ul>
 				{?user}
@@ -44,11 +44,11 @@
 			</nav>
 		</header>
 		<hr>
-		<main class="row">
+		<main>
 			{+content/}
 		</main>
 		<hr>
-		<footer class="row">
+		<footer>
 			<p>This project is proudly opensource. Contibute or check out the code at <a href="https://github.com/frontyardprojects/a-non-cash-assets-library" target="__blank">github</a>.</p>
 		</footer>
 	</div>

--- a/views/base.dust
+++ b/views/base.dust
@@ -7,44 +7,44 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
-	<div class="wrapper">
-		<header>
-			<nav id="user-nav">
-				<ul>
+	<header class="site-header">
+		<nav id="main-nav">
+			<h1 class="site-title">{title}</h1>
+			<ul>
+				{#menu}
+					<li>
+						<span>{@ne key=link value=path}<a href="{link}" title="{title}">{name}</a>{:else}{name}{/ne}</span>
+					</li>
+				{/menu}
 				{?user}
 					<li>
-						(Logged in as <a href="/profile">{user.name}</a>)
-					</li>
-					<li>
-						<a href="/logout">logout</a>
-					</li>
-				{:else}
-					<li>
-						<a href="/login">login</a> or 
-					</li>
-					<li>
-						<a href="/signup">sign up</a>
+						<span>{@ne key=path value="/profile"}<a href="/profile" title="{title}">Profile</a>{:else}Profile{/ne}</span>
 					</li>
 				{/user}
-				</ul>
-			</nav>
-			<h1>{title}</h1>
-			<nav id="main-nav">
-				<ul>
-					{#menu}
-						<li>
-							<span>{@ne key=link value=path}<a href="{link}" title="{title}">{name}</a>{:else}{name}{/ne}</span>
-						</li>
-					{/menu}
-					{?user}
-						<li>
-							<span>{@ne key=path value="/profile"}<a href="/profile" title="{title}">Profile</a>{:else}Profile{/ne}</span>
-						</li>
-					{/user}
-				</ul>
-			</nav>
-		</header>
-		<hr>
+			</ul>
+		</nav>
+		<nav id="user-nav">
+			<ul>
+			{?user}
+				<li>
+					(Logged in as <a href="/profile">{user.name}</a>)
+				</li>
+				<li>
+					<a href="/logout">logout</a>
+				</li>
+			{:else}
+				<li>
+					<a href="/login">login</a> or 
+				</li>
+				<li>
+					<a href="/signup">sign up</a>
+				</li>
+			{/user}
+			</ul>
+		</nav>
+	</header>
+	<hr>
+	<div class="wrapper">
 		<main>
 			{+content/}
 		</main>

--- a/views/base.dust
+++ b/views/base.dust
@@ -4,6 +4,7 @@
 	<meta charset="UTF-8">
 	<title>{title}</title>
 	<link rel="stylesheet" type="text/css" href="/css/style.min.css">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 	<div class="wrapper">

--- a/views/partials/match_have.dust
+++ b/views/partials/match_have.dust
@@ -1,0 +1,30 @@
+<div class="thing {^public}hidden{/public}" data-id={thing_id}>
+	<h3>
+		{@select key=permission }
+			{@eq value="admin"}
+				{owner}
+			{/eq}
+			{@eq value="owner"}
+				{owner}
+			{/eq}
+			{@none}
+				{?anon}someone{:else}{owner}{/anon}
+			{/none}
+		{/select} 
+		has 
+		{name}
+	</h3>
+	<div>
+		{@select key=permission}
+			{@eq value="admin"}
+				<a href="/profile/edit/{type}?id={id}">edit</a> 
+				<a href="/admin/matchmaker/{type}?id={id}">find matches</a>
+			{/eq}
+			{@eq value="owner"}
+				<a href="/profile/edit/{type}?id={id}">edit</a> 
+			{/eq}
+			{@none}{/none}
+		{/select}
+	</div>
+	<p>{description}</p>
+</div>

--- a/views/partials/match_need.dust
+++ b/views/partials/match_need.dust
@@ -1,0 +1,30 @@
+<div class="thing {^public}hidden{/public}" data-id={thing_id}>
+	<h3>
+		{@select key=permission }
+			{@eq value="admin"}
+				{owner}
+			{/eq}
+			{@eq value="owner"}
+				{owner}
+			{/eq}
+			{@none}
+				{?anon}someone{:else}{owner}{/anon}
+			{/none}
+		{/select} 
+		needs 
+		{name}
+	</h3>
+	<div>
+		{@select key=permission}
+			{@eq value="admin"}
+				<a href="/profile/edit/{type}?id={id}">edit</a> 
+				<a href="/admin/matchmaker/{type}?id={id}">find matches</a>
+			{/eq}
+			{@eq value="owner"}
+				<a href="/profile/edit/{type}?id={id}">edit</a> 
+			{/eq}
+			{@none}{/none}
+		{/select}
+	</div>
+	<p>{description}</p>
+</div>

--- a/views/partials/things.dust
+++ b/views/partials/things.dust
@@ -1,4 +1,4 @@
-<div class="table">
+<div class="things-list">
 	<div class="cell">
 		<section id="needs">
 			<h2>Needs</h2>

--- a/views/profile/match.dust
+++ b/views/profile/match.dust
@@ -1,12 +1,11 @@
-<h4>Match (id:{match.match_id}): status {match.status}</h4>
-{#have}
-	<h5>HAVE</h5>
-	{>"../partials/match_have" type="have"/}
-{/have}
-{#need}
-	<h5>NEED</h5>
-	{>"../partials/match_need" type="need"/}
-{/need}
+<article class="match-pair">
+	{#have}
+		{>"../partials/match_have" type="have"/}
+	{/have}
+	{#need}
+		{>"../partials/match_need" type="need"/}
+	{/need}
+<section class="match-actions">
 {?your_have}
 	{@select key=match.status}
 		{@eq value=1} {! match suggested !}
@@ -69,3 +68,5 @@
 		{/none}
 	{/select}
 {/your_have}
+</section class="match-actions">
+</article>

--- a/views/profile/match.dust
+++ b/views/profile/match.dust
@@ -15,10 +15,10 @@
 				<form action="/profile/matches/offer" method="post">
 					<input type="hidden" name="match_id" value="{match.match_id}">
 					<li>
-						<button type="submit">Discuss sharing this with {need.owner}</button>
+						<button class="primary-button button" type="submit">Discuss sharing this with {need.owner}</button>
 					</li>
 					<li>
-						<button type="submit" formaction="/profile/matches/dismiss">Dismiss</button>
+						<button class="button" type="submit" formaction="/profile/matches/dismiss">Dismiss</button>
 					</li>
 				</form>
 			</ul>
@@ -29,7 +29,7 @@
 		{@eq value=3}
 			<ul>
 				<li>
-					<a href="/profile/matches/chat?match_id={match.match_id}">Discuss now.</a>
+					<a class="primary-button button" href="/profile/matches/chat?match_id={match.match_id}">Discuss now.</a>
 				</li>
 			</ul>
 		{/eq}
@@ -47,10 +47,10 @@
 				<form action="/profile/matches/accept" method="post">
 					<input type="hidden" name="match_id" value="{match.match_id}">
 					<li>
-						<button type="submit">Accept Offer</button>
+						<button class="primary-button button" type="submit">Accept Offer</button>
 					</li>
 					<li>
-						<button type="submit" formaction="/profile/matches/dismiss">Dismiss</button>
+						<button class="button" type="submit" formaction="/profile/matches/dismiss">Dismiss</button>
 					</li>
 				</form>
 			</ul>
@@ -58,7 +58,7 @@
 		{@eq value=3}
 			<ul>
 				<li>
-					<a href="/profile/matches/chat?match_id={match.match_id}">Discuss now.</a>
+					<a class="primary-button button" href="/profile/matches/chat?match_id={match.match_id}">Discuss now.</a>
 				</li>
 			</ul>
 		{/eq}

--- a/views/profile/match.dust
+++ b/views/profile/match.dust
@@ -1,11 +1,11 @@
 <h4>Match (id:{match.match_id}): status {match.status}</h4>
 {#have}
 	<h5>HAVE</h5>
-	{>"../partials/thing" type="have"/}
+	{>"../partials/match_have" type="have"/}
 {/have}
 {#need}
 	<h5>NEED</h5>
-	{>"../partials/thing" type="need"/}
+	{>"../partials/match_need" type="need"/}
 {/need}
 {?your_have}
 	{@select key=match.status}

--- a/views/profile/match.dust
+++ b/views/profile/match.dust
@@ -1,10 +1,12 @@
 <article class="match-pair">
-	{#have}
-		{>"../partials/match_have" type="have"/}
-	{/have}
-	{#need}
-		{>"../partials/match_need" type="need"/}
-	{/need}
+	<div class="match-things">
+		{#have}
+			{>"../partials/match_have" type="have"/}
+		{/have}
+		{#need}
+			{>"../partials/match_need" type="need"/}
+		{/need}
+	</div>
 <section class="match-actions">
 {?your_have}
 	{@select key=match.status}

--- a/views/profile/matches.dust
+++ b/views/profile/matches.dust
@@ -4,17 +4,10 @@
 {?message}<div class="message">{message}</div>{/message}
 <h2>Your Matches</h2>
 <hr>
-<h3>Your haves match the following:</h3>
 {#user.have_matches}
 	{>match your_have="true" /}
-{:else}
-	<p>Your haves currently do not match any needs</p>
 {/user.have_matches}
-<hr>
-<h3>Your needs match the following:</h3>
 {#user.need_matches}
 	{>match/}
-{:else}
-	<p>Your needs currently do not match any haves</p>
 {/user.need_matches}
 {/content}

--- a/views/profile/matches.dust
+++ b/views/profile/matches.dust
@@ -3,7 +3,6 @@
 {?error}<div class="error">{error}</div>{/error}
 {?message}<div class="message">{message}</div>{/message}
 <h2>Your Matches</h2>
-<hr>
 {#user.have_matches}
 	{>match your_have="true" /}
 {/user.have_matches}

--- a/views/profile/matches.dust
+++ b/views/profile/matches.dust
@@ -10,4 +10,5 @@
 {#user.need_matches}
 	{>match/}
 {/user.need_matches}
+<!--  TODO: if there's nothing say something -->
 {/content}


### PR DESCRIPTION
This PR makes two major changes:
- flattens out the navigation so that more focus can be placed on the page content
- strips back the design of matches

I've tried to strip it back a bit but still only make a small iteration:
## Navigation

![screen shot 2016-08-25 at 8 03 51 pm](https://cloud.githubusercontent.com/assets/1239550/17965278/18b36946-6aff-11e6-8450-01b9f6278e69.png)
## Match layout

![screen shot 2016-08-25 at 7 58 21 pm](https://cloud.githubusercontent.com/assets/1239550/17965286/25a8b53e-6aff-11e6-8756-515d0f14bcb2.png)
## TODO

@e-e-e I couldn't work out how to change the "owner" name for your stuff in the matches from "equivalentideas has" to "you have". I think that would make it loads clearer.

![screen shot 2016-08-25 at 7 58 21 pm](https://cloud.githubusercontent.com/assets/1239550/17965493/4122cf10-6b00-11e6-9b06-661a244ca01c.png)
